### PR TITLE
Fixed support for virion v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This virion was made for developers to query Pocketmine-MP servers with ease. He
 ### Required imports
 The following imports are necessary to use the virion library:
 ```php
-use libpmquery\PMQuery;
-use libpmquery\PmQueryException;
+use jasonw4331\libpmquery\PMQuery;
+use jasonw4331\libpmquery\PmQueryException;
 ```
 
 ### API

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {
-			"libpmquery\\": "/src/libpmquery"
+			"jasonw4331\\libpmquery\\": "/src/jasonw4331/libpmquery"
 		}
 	},
 	"require": {

--- a/src/jasonw4331/libpmquery/PMQuery.php
+++ b/src/jasonw4331/libpmquery/PMQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace libpmquery;
+namespace jasonw4331\libpmquery;
 
 use function explode;
 use function fclose;

--- a/src/jasonw4331/libpmquery/PmQueryException.php
+++ b/src/jasonw4331/libpmquery/PmQueryException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace libpmquery;
+namespace jasonw4331\libpmquery;
 
 class PmQueryException extends \Exception{
 }

--- a/virion.yml
+++ b/virion.yml
@@ -1,6 +1,6 @@
 name: libpmquery
 version: 1.0.0
-antigen: libpmquery
+antigen: jasonw4331\libpmquery
 php:
  - 7.4
  - 8.0


### PR DESCRIPTION
## Introduction

<!-- Explain existing problems or why this pull request is necessary -->
Virion v3 only supports virions that use the namespace format `AuthorName\VirionName`.

## Changes

## Backwards compatibility

<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Changed namespace `libpmquery` to `jasonw4331\libpmquery`.